### PR TITLE
Revamp frontend for model testing

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,12 +1,17 @@
-# React + Vite
+# IA-Rag Frontend
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Interfaz en React para experimentar con modelos locales usando Ollama y RAG.
 
-Currently, two official plugins are available:
+## Características
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+- Selector de modelo y cliente para aislar pruebas.
+- Chat con historial de mensajes para probar los modelos.
+- Panel para subir documentos y generar contexto.
+- Herramientas de administración para limpiar datos.
 
-## Expanding the ESLint configuration
+## Scripts
 
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+- `npm run dev` - inicia el entorno de desarrollo.
+- `npm run build` - genera la versión de producción.
+- `npm run lint` - verifica el código con ESLint.
+

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,38 +4,60 @@ import ChatBox from "./components/ChatBox";
 import UploadPanel from "./components/UploadPanel";
 import AdminPanel from "./components/AdminPanel";
 
-
-
 const MODELS = ["llama3.1:8b", "qwen3:8b", "llama3.2:3b"];
+const TABS = [
+  { id: "chat", label: "Chat" },
+  { id: "docs", label: "Documentos" },
+  { id: "admin", label: "Admin" },
+];
 
 export default function App() {
   const [model, setModel] = useState(MODELS[0]);
   const [clientId, setClientId] = useState("acme");
+  const [tab, setTab] = useState("chat");
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      <header className="p-4 border-b bg-white">
+    <div className="min-h-screen bg-gray-50 flex flex-col">
+      <header className="p-4 border-b bg-white flex items-center justify-between">
         <h1 className="text-xl font-semibold">Local AI Chat (Ollama + RAG)</h1>
+        <nav className="flex gap-2">
+          {TABS.map((t) => (
+            <button
+              key={t.id}
+              onClick={() => setTab(t.id)}
+              className={`px-3 py-1 rounded ${
+                tab === t.id ? "bg-black text-white" : "bg-gray-200"
+              }`}
+            >
+              {t.label}
+            </button>
+          ))}
+        </nav>
       </header>
-      <UploadPanel clientId={clientId} />
-<AdminPanel clientId={clientId} />
 
-      <main className="max-w-3xl mx-auto p-4 space-y-4">
-        <div className="grid sm:grid-cols-3 gap-3">
-          <ModelPicker value={model} onChange={setModel} models={MODELS} />
-          <div className="sm:col-span-2">
-            <label className="block text-sm font-medium">Cliente (aislamiento)</label>
-            <input
-              className="mt-1 border rounded p-2 w-full"
-              value={clientId}
-              onChange={(e) => setClientId(e.target.value)}
-            />
-          </div>
-        </div>
+      <main className="flex-grow max-w-3xl mx-auto p-4 space-y-4 w-full">
+        {tab === "chat" && (
+          <>
+            <div className="grid sm:grid-cols-3 gap-3">
+              <ModelPicker value={model} onChange={setModel} models={MODELS} />
+              <div className="sm:col-span-2">
+                <label className="block text-sm font-medium">Cliente (aislamiento)</label>
+                <input
+                  className="mt-1 border rounded p-2 w-full"
+                  value={clientId}
+                  onChange={(e) => setClientId(e.target.value)}
+                />
+              </div>
+            </div>
+            <ChatBox model={model} clientId={clientId} />
+          </>
+        )}
 
-        <ChatBox model={model} clientId={clientId} />
-        <UploadPanel clientId={clientId} />
+        {tab === "docs" && <UploadPanel clientId={clientId} />}
+
+        {tab === "admin" && <AdminPanel clientId={clientId} />}
       </main>
     </div>
   );
 }
+

--- a/frontend/src/components/AdminPanel.jsx
+++ b/frontend/src/components/AdminPanel.jsx
@@ -8,7 +8,7 @@ export default function AdminPanel({ clientId }) {
   const wipeClient = async () => {
     setMsg("");
     try {
-      const res = await deleteByClient({ client_id: clientId, adminToken: token });
+      await deleteByClient({ client_id: clientId, adminToken: token });
       setMsg(`OK: borrado cliente "${clientId}"`);
     } catch (e) {
       setMsg("Error: " + e.message);
@@ -18,7 +18,7 @@ export default function AdminPanel({ clientId }) {
   const wipeAll = async () => {
     setMsg("");
     try {
-      const res = await deleteAll({ adminToken: token });
+      await deleteAll({ adminToken: token });
       setMsg("OK: reset total");
     } catch (e) {
       setMsg("Error: " + e.message);

--- a/frontend/src/components/ChatBox.jsx
+++ b/frontend/src/components/ChatBox.jsx
@@ -1,37 +1,66 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { chat } from "../lib/api";
 
 export default function ChatBox({ model, clientId }) {
   const [msg, setMsg] = useState("");
-  const [reply, setReply] = useState("");
-  const [meta, setMeta] = useState("");
+  const [messages, setMessages] = useState([]);
   const [loading, setLoading] = useState(false);
+  const endRef = useRef(null);
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
 
   const send = async () => {
     if (!msg.trim()) return;
+    const userText = msg;
+    setMsg("");
+    setMessages((prev) => [...prev, { sender: "user", text: userText }]);
     setLoading(true);
-    setReply(""); setMeta("");
     try {
-      const data = await chat({ message: msg, model, client_id: clientId });
-      setReply(data.reply || JSON.stringify(data));
+      const data = await chat({ message: userText, model, client_id: clientId });
+      let meta = "";
       if (data.citations?.length) {
-        setMeta(`Contexto usado: ${data.citations.map(c => `${c.source}#${c.chunk}`).join(", ")}`);
+        meta = `Contexto usado: ${data.citations
+          .map((c) => `${c.source}#${c.chunk}`)
+          .join(", ")}`;
       } else if (data.used_context === 0 && clientId) {
-        setMeta("Sin contexto (no hay docs indexados para este cliente).");
+        meta = "Sin contexto (no hay docs indexados para este cliente).";
       }
+      setMessages((prev) => [
+        ...prev,
+        { sender: "bot", text: data.reply || JSON.stringify(data), meta },
+      ]);
     } catch (e) {
-      setReply("Error: " + e.message);
+      setMessages((prev) => [
+        ...prev,
+        { sender: "bot", text: "Error: " + e.message },
+      ]);
     } finally {
       setLoading(false);
     }
   };
 
   return (
-    <div className="p-3 border rounded bg-white flex flex-col gap-2">
-      <div className="flex gap-2">
+    <div className="flex flex-col h-[400px] border rounded bg-white">
+      <div className="flex-1 overflow-y-auto p-3 flex flex-col gap-2">
+        {messages.map((m, idx) => (
+          <div
+            key={idx}
+            className={`max-w-[80%] p-2 rounded ${
+              m.sender === "user" ? "bg-blue-100 self-end" : "bg-gray-100 self-start"
+            }`}
+          >
+            <pre className="whitespace-pre-wrap">{m.text}</pre>
+            {m.meta && <div className="text-xs text-gray-500 mt-1">{m.meta}</div>}
+          </div>
+        ))}
+        <div ref={endRef} />
+      </div>
+      <div className="p-3 border-t flex gap-2">
         <input
           className="flex-1 border rounded p-2"
-          placeholder="Escribe tu mensaje y presiona Enter…"
+          placeholder="Escribe tu mensaje..."
           value={msg}
           onChange={(e) => setMsg(e.target.value)}
           onKeyDown={(e) => e.key === "Enter" && send()}
@@ -41,11 +70,10 @@ export default function ChatBox({ model, clientId }) {
           disabled={loading}
           className="px-4 py-2 rounded bg-black text-white disabled:opacity-50"
         >
-          {loading ? "Enviando..." : "Enviar"}
+          {loading ? "..." : "Enviar"}
         </button>
       </div>
-      <pre className="whitespace-pre-wrap p-3 bg-gray-100 rounded min-h-[120px]">{reply}</pre>
-      {meta && <div className="text-sm text-gray-600">{meta}</div>}
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- Add tabbed navigation to switch between chat, document upload, and admin tools
- Implement chat message history with auto-scroll
- Document frontend features and scripts

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7c543be44832ca0351d1adb82341c