### PR TITLE
feat: make chat context ephemeral per tab

### DIFF
--- a/frontend/src/components/ChatBox.jsx
+++ b/frontend/src/components/ChatBox.jsx
@@ -5,6 +5,8 @@ export default function ChatBox({ model, clientId }) {
   const [msg, setMsg] = useState("");
   const [messages, setMessages] = useState([]);
   const [loading, setLoading] = useState(false);
+  // ID de conversación efímero; solo vive en memoria del componente
+  const [conversationId] = useState(() => crypto.randomUUID());
   const endRef = useRef(null);
 
   useEffect(() => {
@@ -18,7 +20,12 @@ export default function ChatBox({ model, clientId }) {
     setMessages((prev) => [...prev, { sender: "user", text: userText }]);
     setLoading(true);
     try {
-      const data = await chat({ message: userText, model, client_id: clientId });
+      const data = await chat({
+        message: userText,
+        model,
+        client_id: clientId,
+        conversation_id: conversationId,
+      });
       let meta = "";
       if (data.citations?.length) {
         meta = `Contexto usado: ${data.citations

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -15,10 +15,17 @@ async function _checkResponse(res) {
   throw new Error(msg);
 }
 
-export async function chat({ message, model, client_id, mode } = {}) {
+export async function chat({
+  message,
+  model,
+  client_id,
+  conversation_id,
+  mode,
+} = {}) {
   const body = { message };
   if (model) body.model = model;
   if (client_id) body.client_id = client_id;
+  if (conversation_id) body.conversation_id = conversation_id;
   if (mode) body.mode = mode;
 
   const r = await fetch(`${API}/chat`, {


### PR DESCRIPTION
## Summary
- generate runtime-only `conversation_id` in the chat component and send it with each request
- track conversations in backend memory keyed by `conversation_id` instead of `client_id`
- allow clearing context using new `conversation_id` parameter

## Testing
- `python -m py_compile main.py`
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7cca12478832cbe2eafaa0be38681